### PR TITLE
Create functions to get/set calibration data

### DIFF
--- a/bno055.c
+++ b/bno055.c
@@ -8,7 +8,13 @@ uint16_t magScale = 16;
 
 void bno055_setPage(uint8_t page) { bno055_writeData(BNO055_PAGE_ID, page); }
 
-void bno055_setOperationMode(uint8_t mode) {
+bno055_opmode_t bno055_getOperationMode() {
+  bno055_opmode_t mode;
+  bno055_readData(BNO055_OPR_MODE, &mode, 1);
+  return mode;
+}
+
+void bno055_setOperationMode(bno055_opmode_t mode) {
   bno055_writeData(BNO055_OPR_MODE, mode);
   bno055_delay(30);
 }

--- a/bno055.c
+++ b/bno055.c
@@ -102,15 +102,15 @@ uint8_t bno055_getSystemError() {
   return tmp;
 }
 
-bno055_calibration_t bno055_getCalibration() {
+bno055_calibration_state_t bno055_getCalibrationState() {
   bno055_setPage(0);
-  bno055_calibration_t cal = {.sys = 0, .gyro = 0, .mag = 0, .accel = 0};
-  uint8_t calData = 0;
-  bno055_readData(BNO055_CALIB_STAT, &calData, 1);
-  cal.sys = (calData >> 6) & 0x03;
-  cal.gyro = (calData >> 4) & 0x03;
-  cal.accel = (calData >> 2) & 0x03;
-  cal.mag = calData & 0x03;
+  bno055_calibration_state_t cal = {.sys = 0, .gyro = 0, .mag = 0, .accel = 0};
+  uint8_t calState = 0;
+  bno055_readData(BNO055_CALIB_STAT, &calState, 1);
+  cal.sys = (calState >> 6) & 0x03;
+  cal.gyro = (calState >> 4) & 0x03;
+  cal.accel = (calState >> 2) & 0x03;
+  cal.mag = calState & 0x03;
   return cal;
 }
 

--- a/bno055.c
+++ b/bno055.c
@@ -156,9 +156,9 @@ void bno055_setCalibrationData(bno055_calibration_data_t calData) {
   memcpy(buffer + 18, &calData.radius.accel, 2);
   memcpy(buffer + 20, &calData.radius.mag, 2);
 
-  for (uint8_t i=0; i<22; i++) {
-	  // TODO: create multibytes write
-	  bno055_writeData(BNO055_ACC_OFFSET_X_LSB+i, buffer[i]);
+  for (uint8_t i=0; i < 22; i++) {
+    // TODO(oliv4945): create multibytes write
+    bno055_writeData(BNO055_ACC_OFFSET_X_LSB+i, buffer[i]);
   }
 
   bno055_setOperationMode(operationMode);

--- a/bno055.h
+++ b/bno055.h
@@ -197,6 +197,28 @@ typedef struct {
 } bno055_calibration_state_t;
 
 typedef struct {
+  int16_t x;
+  int16_t y;
+  int16_t z;
+} bno055_vector_xyz_int16_t;
+
+typedef struct {
+  bno055_vector_xyz_int16_t gyro;
+  bno055_vector_xyz_int16_t mag;
+  bno055_vector_xyz_int16_t accel;
+} bno055_calibration_offset_t;
+
+typedef struct {
+  uint16_t mag;
+  uint16_t accel;
+} bno055_calibration_radius_t;
+
+typedef struct {
+  bno055_calibration_offset_t offset;
+  bno055_calibration_radius_t radius;
+} bno055_calibration_data_t;
+
+typedef struct {
   double x;
   double y;
   double z;
@@ -247,6 +269,8 @@ int16_t bno055_getSWRevision();
 
 bno055_self_test_result_t bno055_getSelfTestResult();
 bno055_calibration_state_t bno055_getCalibrationState();
+bno055_calibration_data_t bno055_getCalibrationData();
+void bno055_setCalibrationData(bno055_calibration_data_t calData);
 bno055_vector_t bno055_getVectorAccelerometer();
 bno055_vector_t bno055_getVectorMagnetometer();
 bno055_vector_t bno055_getVectorGyroscope();

--- a/bno055.h
+++ b/bno055.h
@@ -164,7 +164,7 @@ enum bno055_system_status_t {
   BNO055_SYSTEM_STATUS_FUSION_ALOG_NOT_RUNNING = 0x06
 };
 
-enum bno055_opmode_t {  // BNO-55 operation modes
+typedef enum {  // BNO-55 operation modes
   BNO055_OPERATION_MODE_CONFIG = 0x00,
   // Sensor Mode
   BNO055_OPERATION_MODE_ACCONLY,
@@ -180,7 +180,7 @@ enum bno055_opmode_t {  // BNO-55 operation modes
   BNO055_OPERATION_MODE_M4G,
   BNO055_OPERATION_MODE_NDOF_FMC_OFF,
   BNO055_OPERATION_MODE_NDOF  // 0x0C
-};
+} bno055_opmode_t;
 
 typedef struct {
   uint8_t mcuState;
@@ -230,7 +230,8 @@ void bno055_readData(uint8_t reg, uint8_t *data, uint8_t len);
 void bno055_delay(int time);
 
 void bno055_reset();
-void bno055_setOperationMode(uint8_t mode);
+bno055_opmode_t bno055_getOperationMode();
+void bno055_setOperationMode(bno055_opmode_t mode);
 void bno055_setOperationModeConfig();
 void bno055_setOperationModeNDOF();
 void bno055_enableExternalCrystal();

--- a/bno055.h
+++ b/bno055.h
@@ -194,7 +194,7 @@ typedef struct {
   uint8_t gyro;
   uint8_t mag;
   uint8_t accel;
-} bno055_calibration_t;
+} bno055_calibration_state_t;
 
 typedef struct {
   double x;
@@ -245,7 +245,7 @@ uint8_t bno055_getSystemError();
 int16_t bno055_getSWRevision();
 
 bno055_self_test_result_t bno055_getSelfTestResult();
-bno055_calibration_t bno055_getCalibration();
+bno055_calibration_state_t bno055_getCalibrationState();
 bno055_vector_t bno055_getVectorAccelerometer();
 bno055_vector_t bno055_getVectorMagnetometer();
 bno055_vector_t bno055_getVectorGyroscope();


### PR DESCRIPTION
This allows to save calibration data in host EEPROM,then write them again to the bno in order avoid calibration at each POR